### PR TITLE
Refactor Tradier API handling

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,3 @@
-import requests
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta, timezone
@@ -8,6 +7,8 @@ import streamlit as st
 from zoneinfo import ZoneInfo
 import yaml
 import os
+
+from tradier_api import TradierAPI
 
 # Load configuration from YAML file
 with open(os.path.join(os.path.dirname(__file__), "config.yaml"), "r") as f:
@@ -57,13 +58,8 @@ def fetch_and_filter_rss(feeds=RSS_FEEDS, topics=TOPICS, limit_per_feed=10):
     return uniq
 
 def get_expirations(ticker, token, include_all_roots=False):
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
-    params = {"symbol": ticker}
-    if include_all_roots:
-        params["includeAllRoots"] = "true"
-    r = requests.get(f"{API_URL}/markets/options/expirations", params=params, headers=headers)
-    r.raise_for_status()
-    return r.json().get("expirations", {}).get("date", [])
+    api = TradierAPI(token, API_URL)
+    return api.expirations(ticker, include_all_roots)
 
 def load_options_data(ticker, expirations, token):
     """Fetch option chains and process data for positioning."""
@@ -96,22 +92,13 @@ def load_options_data(ticker, expirations, token):
 
 
 def get_option_chain(ticker, expiration, token, include_all_roots=True):
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
-    params = {"symbol": ticker, "expiration": expiration, "greeks": "true"}
-    if include_all_roots:
-        params["includeAllRoots"] = "true"
-    r = requests.get(f"{API_URL}/markets/options/chains", params=params, headers=headers)
-    r.raise_for_status()
-    return r.json().get("options", {}).get("option", [])
+    api = TradierAPI(token, API_URL)
+    return api.option_chain(ticker, expiration, include_all_roots=include_all_roots)
 
 
 def get_stock_quote(ticker, token):
-    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
-    r = requests.get(f"{API_URL}/markets/quotes", params={"symbols": ticker}, headers=headers)
-    r.raise_for_status()
-    data = r.json().get("quotes", {}).get("quote")
-    if isinstance(data, list):
-        data = data[0]
+    api = TradierAPI(token, API_URL)
+    data = api.quote(ticker)
     return data.get("last")
 
 
@@ -186,25 +173,16 @@ def compute_unusual_spikes(df, top_n=10):
 
 
 def compute_greek_exposures(ticker, expirations, tradier_token, offset, spot):
-    headers = {
-        "Authorization": f"Bearer {tradier_token}",
-        "Accept":        "application/json"
-    }
+    api = TradierAPI(tradier_token, API_URL)
 
     rows = []
     for exp in expirations:
-        response = requests.get(
-            f"{API_URL}/markets/options/chains",
-            params={
-                "symbol": ticker,
-                "expiration": exp,
-                "greeks": "true",
-                "includeAllRoots": "true"
-            },
-            headers=headers
+        options = api.option_chain(
+            ticker,
+            exp,
+            greeks="true",
+            include_all_roots=True,
         )
-        response.raise_for_status()
-        options = response.json().get("options", {}).get("option", [])
 
         for opt in options:
             strike = float(opt.get("strike", 0))
@@ -263,19 +241,12 @@ def get_vix_info():
     }
 
 def get_market_snapshot(tradier_token, ticker, expirations, offset=20):
-    headers = {
-        "Authorization": f"Bearer {tradier_token}",
-        "Accept":        "application/json"
-    }
-    
+    api = TradierAPI(tradier_token, API_URL)
+
     payload = {}
     # ── Spot & Quote
-    q = requests.get(
-        f"{API_URL}/markets/quotes",
-        params={"symbols": ticker},
-        headers=headers
-    ).json()["quotes"]["quote"]
-    spot = q["last"]
+    q = api.quote(ticker)
+    spot = q.get("last")
     payload["spot"] = spot
     payload["ticker"] = ticker
     payload["expirations"] = expirations
@@ -285,16 +256,12 @@ def get_market_snapshot(tradier_token, ticker, expirations, offset=20):
     today = datetime.utcnow().date()
     # fetch at least 14 trading days to compute RSI(14)
     start = today - timedelta(days=30)
-    hist = requests.get(
-        f"{API_URL}/markets/history",
-        params={
-            "symbol":   ticker,
-            "interval": "daily",
-            "start":    start.isoformat(),
-            "end":      today.isoformat()
-        },
-        headers=headers
-    ).json().get("history", {}).get("day", [])
+    hist = api.history(
+        ticker,
+        interval="daily",
+        start=start.isoformat(),
+        end=today.isoformat(),
+    )
     df_hist = pd.DataFrame(hist)
     df_hist["date"]  = pd.to_datetime(df_hist["date"])
     df_hist = df_hist.sort_values("date").set_index("date")
@@ -424,15 +391,15 @@ def compute_term_structure_slope(tradier_token, ticker, expirations, spot, offse
     Compute term structure slope = IV_near - IV_far for your ±offset strikes.
     Uses the first and last in expirations list.
     """
-    API_URL = "https://api.tradier.com/v1"
-    headers = {"Authorization": f"Bearer {tradier_token}", "Accept":"application/json"}
+    api = TradierAPI(tradier_token, API_URL)
     ivs = []
     for exp in [expirations[0], expirations[-1]]:
-        resp = requests.get(
-            f"{API_URL}/markets/options/chains",
-            params={"symbol": ticker, "expiration": exp, "greeks": "false", "includeAllRoots":"true"},
-            headers=headers
-        ).json().get("options", {}).get("option", [])
+        resp = api.option_chain(
+            ticker,
+            exp,
+            greeks="false",
+            include_all_roots=True,
+        )
         df = pd.DataFrame(resp)
         greeks_df = pd.json_normalize(df.greeks)
         df = pd.concat([df, greeks_df], axis=1)
@@ -462,16 +429,15 @@ def augment_payload_with_extras(payload, tradier_token, ticker, expirations, off
     to an existing payload dict.
     """
     # use first expiration's chain
-    API_URL = "https://api.tradier.com/v1"
-    headers = {"Authorization": f"Bearer {tradier_token}", "Accept":"application/json"}
+    api = TradierAPI(tradier_token, API_URL)
     all_opts = []
     for exp in expirations:
-        resp = requests.get(
-            f"{API_URL}/markets/options/chains",
-            params={"symbol": ticker, "expiration": exp, "greeks":"true", "includeAllRoots":"true"},
-            headers=headers
+        chain0 = api.option_chain(
+            ticker,
+            exp,
+            greeks="true",
+            include_all_roots=True,
         )
-        chain0 = resp.json().get("options", {}).get("option", [])
         all_opts.extend(chain0)
     
     df = pd.DataFrame(all_opts)

--- a/tradier_api.py
+++ b/tradier_api.py
@@ -1,0 +1,63 @@
+import requests
+from typing import Any, Dict, List, Optional
+
+
+class TradierAPI:
+    """Simple wrapper around the Tradier REST API."""
+
+    def __init__(self, token: str, base_url: str = "https://api.tradier.com/v1"):
+        self.base_url = base_url.rstrip("/")
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
+
+    def get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        resp = requests.get(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    # Convenience wrappers --------------------------------------------------
+    def option_chain(
+        self,
+        symbol: str,
+        expiration: str,
+        greeks: str = "true",
+        include_all_roots: bool = True,
+    ) -> List[Dict[str, Any]]:
+        params = {"symbol": symbol, "expiration": expiration, "greeks": greeks}
+        if include_all_roots:
+            params["includeAllRoots"] = "true"
+        data = self.get("markets/options/chains", params)
+        return data.get("options", {}).get("option", [])
+
+    def expirations(self, symbol: str, include_all_roots: bool = False) -> List[str]:
+        params = {"symbol": symbol}
+        if include_all_roots:
+            params["includeAllRoots"] = "true"
+        data = self.get("markets/options/expirations", params)
+        return data.get("expirations", {}).get("date", [])
+
+    def quote(self, symbol: str) -> Dict[str, Any]:
+        data = self.get("markets/quotes", {"symbols": symbol})
+        q = data.get("quotes", {}).get("quote")
+        if isinstance(q, list):
+            q = q[0]
+        return q or {}
+
+    def history(
+        self,
+        symbol: str,
+        interval: str = "daily",
+        start: Optional[str] = None,
+        end: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        params = {"symbol": symbol, "interval": interval}
+        if start:
+            params["start"] = start
+        if end:
+            params["end"] = end
+        data = self.get("markets/history", params)
+        return data.get("history", {}).get("day", [])
+


### PR DESCRIPTION
## Summary
- introduce `TradierAPI` class to wrap HTTP calls
- refactor helper functions to use the new API client
- update utilities for delta exposure calculation

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fff0327648322af86648d61133869