### PR TITLE
Add global thread debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Run the project locally with:
 streamlit run quant.py
 ```
 
+### Optional Thread Debugging
+
+Set the environment variable `THREAD_DEBUG=1` before running the app to log
+thread creation and completion across all modules.
+
 ## Testing
 
 Tests can be added under a `tests/` directory; then run:

--- a/helpers.py
+++ b/helpers.py
@@ -9,6 +9,14 @@ from zoneinfo import ZoneInfo
 import yaml
 import os
 
+# Optionally enable thread debugging across the app
+if os.getenv("THREAD_DEBUG"):
+    try:
+        from thread_debug import enable as enable_thread_debug
+        enable_thread_debug()
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"Thread debug failed: {e}")
+
 # Load configuration from YAML file
 with open(os.path.join(os.path.dirname(__file__), "config.yaml"), "r") as f:
     CONFIG = yaml.safe_load(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,4 +98,5 @@ watchdog==6.0.0
 websockets==14.2
 yarl==1.20.0
 yfinance==0.2.61
-pyaml
+pyyaml
+psutil==7.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "pandas",
         "supabase",
         "pyyaml",
+        "psutil",
     ],
     entry_points={
         "console_scripts": [

--- a/sync.py
+++ b/sync.py
@@ -1,6 +1,14 @@
 import yaml
 import os
 
+# Optionally enable thread debugging
+if os.getenv("THREAD_DEBUG"):
+    try:
+        from thread_debug import enable as enable_thread_debug
+        enable_thread_debug()
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"Thread debug failed: {e}")
+
 # Load configuration from YAML file
 with open(os.path.join(os.path.dirname(__file__), "config.yaml"), "r") as f:
     CONFIG = yaml.safe_load(f)

--- a/thread_debug.py
+++ b/thread_debug.py
@@ -1,0 +1,37 @@
+import threading
+import psutil
+import time
+import os
+
+_original_start = threading.Thread.start
+_original_run = threading.Thread.run
+
+
+def _patched_start(self, *args, **kwargs):
+    self._debug_start_time = time.perf_counter()
+    target = getattr(self, "_target", None)
+    print(
+        f"[thread-debug] starting {self.name} target={getattr(target, '__name__', target)} "
+        f"active={threading.active_count()}"
+    )
+    return _original_start(self, *args, **kwargs)
+
+
+def _patched_run(self, *args, **kwargs):
+    result = _original_run(self, *args, **kwargs)
+    duration = time.perf_counter() - getattr(self, "_debug_start_time", time.perf_counter())
+    mem_mb = psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+    print(
+        f"[thread-debug] finished {self.name} in {duration:.3f}s mem={mem_mb:.2f}MB "
+        f"active={threading.active_count()}"
+    )
+    return result
+
+
+def enable():
+    if getattr(threading, "_debug_enabled", False):
+        return
+    threading.Thread.start = _patched_start
+    threading.Thread.run = _patched_run
+    threading._debug_enabled = True
+    print("[thread-debug] enabled")


### PR DESCRIPTION
## Summary
- enable optional thread debugging via `helpers.py`
- remove per-script enablement from `quant.py`
- allow `sync.py` to enable debugging when used
- document how to turn it on

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840078a123c8322a72121a4d7276fb8