### PR TITLE
Improve delta projection plot

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ from utils import (
     plot_volume_spikes_stacked,
     interpret_net_gex,
     plot_exposure,
-    plot_price_and_delta_projection
+    plot_price_and_delta_projection,
+    get_recent_trading_dates
 )
 from quant import openai_query
 from db import init_db, save_analysis, load_analyses
@@ -158,9 +159,20 @@ with tab1:
         fig = plot_volume_spikes_stacked(spikes_df, offset=offset, spot=spot)
         st.plotly_chart(fig, use_container_width=True)
 
-        # Price and dealers detla hedge and projection
-        # fig = plot_price_and_delta_projection(ticker, exp0, tradier_token, offset=offset)
-        # st.plotly_chart(fig, use_container_width=True)
+        # Price and dealers delta hedge and projection
+        dates = get_recent_trading_dates(ticker, 3)
+        if dates:
+            labels = [d.strftime("%Y-%m-%d") for d in reversed(dates)]
+            sel = st.selectbox("Intraday Date", labels)
+            days_ago = labels.index(sel)
+            fig_delta = plot_price_and_delta_projection(
+                ticker,
+                exp0,
+                tradier_token,
+                offset=offset,
+                days_ago=days_ago,
+            )
+            st.plotly_chart(fig_delta, use_container_width=True)
     else:
         st.info("Select ticker, expirations, and ensure spot price loaded.")
 

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import yfinance as yf
 from plotly.subplots import make_subplots
-from datetime import datetime, timedelta, time
+from datetime import datetime, timedelta, time, date
 from tradier_api import TradierAPI
 
 def interpret_net_gex(df_net, S, offset=25):
@@ -338,26 +338,76 @@ def plot_volume_spikes_stacked(spikes_df, offset=None, spot=None):
     fig.update_yaxes(tickfont=dict(size=14))
     return fig
 
-def get_intraday_prices_with_prev_close(ticker: str, interval: str = "30m") -> pd.Series:
-    df = yf.Ticker(ticker).history(period="2d", interval=interval)
-    df['date'] = df.index.date
-    dates = sorted(df['date'].unique())
-    yday, today = dates[0], dates[-1]
+def get_intraday_prices_with_prev_close(
+    ticker: str,
+    interval: str = "30m",
+    days_ago: int = 0,
+) -> pd.Series:
+    """Intraday price series for a given trading day with prior close.
 
-    # yesterday’s final bar at 16:00
-    df_y = df[df['date'] == yday]
-    yday_close = df_y['Close'].iloc[-1]
+    Parameters
+    ----------
+    ticker : str
+        Equity ticker to pull prices for.
+    interval : str, optional
+        Bar interval for intraday prices.
+    days_ago : int, optional
+        Trading days back from today to fetch. ``0`` corresponds to the most
+        recent trading day, ``1`` to the previous day, and so on.
+
+    Returns
+    -------
+    pandas.Series
+        Series of closing prices including the prior day's 16:00 close as the
+        first observation.
+    """
+
+    # we need at least the target day and the day before
+    period_days = days_ago + 2
+    df = yf.Ticker(ticker).history(period=f"{period_days}d", interval=interval)
+    df["date"] = df.index.date
+    dates = sorted(df["date"].unique())
+
+    if len(dates) <= days_ago:
+        raise ValueError("Not enough historical data for requested days_ago")
+
+    target_date = dates[-1 - days_ago]
+    prev_date = dates[dates.index(target_date) - 1]
+
+    # previous day's final bar at 16:00
+    df_prev = df[df["date"] == prev_date]
+    prev_close = df_prev["Close"].iloc[-1]
     tz = df.index.tz
-    yday_ts = datetime.combine(yday, time(16, 0)).replace(tzinfo=tz)
-    ser_y = pd.Series([yday_close], index=pd.DatetimeIndex([yday_ts], tz=tz), name="Close")
+    prev_ts = datetime.combine(prev_date, time(16, 0)).replace(tzinfo=tz)
+    ser_prev = pd.Series([prev_close], index=pd.DatetimeIndex([prev_ts], tz=tz), name="Close")
 
-    # today’s intraday
-    df_t = df[df['date'] == today]['Close'].copy()
-    df_t.name = "Close"
+    # target day intraday
+    df_target = df[df["date"] == target_date]["Close"].copy()
+    df_target.name = "Close"
 
-    # combine
-    combined = pd.concat([ser_y, df_t]).sort_index()
-    return combined
+    return pd.concat([ser_prev, df_target]).sort_index()
+
+def get_recent_trading_dates(ticker: str, n: int = 3) -> list[date]:
+    """Return recent trading dates for a ticker.
+
+    Parameters
+    ----------
+    ticker : str
+        Equity ticker used for fetching historical data.
+    n : int, optional
+        Number of most recent trading days to return. Default ``3``.
+
+    Returns
+    -------
+    list[datetime.date]
+        Sorted list of trading dates, most recent last.
+    """
+
+    df = yf.Ticker(ticker).history(period=f"{n + 3}d", interval="1d")
+    if df.empty:
+        return []
+    dates = sorted(df.index.date)
+    return dates[-n:]
 
 def get_delta_exposure_at_times(
     ticker, expiration, tradier_token, offset, price_series: pd.Series
@@ -396,75 +446,110 @@ def get_delta_exposure_at_times(
     return pd.Series(exposures, index=idx, name="Net Delta Exposure")
 
 def plot_price_and_delta_projection(
-    ticker, expiration, tradier_token, offset, interval="30m"
-):
-    # 1) get price series (with yday close)
-    price_series = get_intraday_prices_with_prev_close(ticker, interval)
+    ticker: str,
+    expiration: str,
+    tradier_token: str,
+    offset: float,
+    interval: str = "30m",
+    days_ago: int = 0,
+) -> go.Figure:
+    """Plot intraday price alongside estimated dealer delta exposure.
 
-    # 2) compute exposures only for today’s bars
+    Parameters
+    ----------
+    ticker : str
+        Equity ticker to chart.
+    expiration : str
+        Expiration used when pulling the option chain.
+    tradier_token : str
+        Auth token for the Tradier API.
+    offset : float
+        Strike range around the current spot when computing exposure.
+    interval : str, optional
+        Intraday bar interval used for price history (default ``"30m"``).
+    days_ago : int, optional
+        Number of trading days in the past to analyze. ``0`` is the most recent
+        day, ``1`` is the previous trading day, etc. Default ``0``.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Figure with spot price on the left axis and net delta exposure on the
+        right. A simple linear projection of the exposure trend to the market
+        close is also included.
+    """
+
+    # ── 1) Intraday prices including the previous close ───────────────────
+    price_series = get_intraday_prices_with_prev_close(ticker, interval, days_ago)
+
+    # ── 2) Delta exposure for each intraday bar ───────────────────────────
     delta_series = get_delta_exposure_at_times(
         ticker, expiration, tradier_token, offset, price_series
     )
 
-    # 3) linear trend on exposures
-    hours = np.array([
-        (ts - delta_series.index[0]).total_seconds()/3600
-        for ts in delta_series.index
-    ])
-    coeff = np.polyfit(hours, delta_series.values, 1)
-    trend = np.poly1d(coeff)
+    # Ensure there are at least two points before fitting a trend
+    if len(delta_series) > 1:
+        hours = np.array(
+            [(ts - delta_series.index[0]).total_seconds() / 3600 for ts in delta_series.index]
+        )
+        coeff = np.polyfit(hours, delta_series.values, 1)
+        trend = np.poly1d(coeff)
+        last_ts = delta_series.index[-1]
+        tz = last_ts.tzinfo
+        end_ts = datetime.combine(last_ts.date(), time(16, 0)).replace(tzinfo=tz)
+        end_hour = (end_ts - delta_series.index[0]).total_seconds() / 3600
+        proj = float(trend(end_hour))
+    else:
+        # fallback if only one bar available
+        last_ts = delta_series.index[-1]
+        tz = last_ts.tzinfo
+        end_ts = datetime.combine(last_ts.date(), time(16, 0)).replace(tzinfo=tz)
+        proj = delta_series.iloc[-1]
 
-    # project to end-of-day 16:00
-    last_ts = delta_series.index[-1]
-    tz = last_ts.tzinfo
-    end_ts = datetime.combine(last_ts.date(), time(16,0)).replace(tzinfo=tz)
-    end_hour = (end_ts - delta_series.index[0]).total_seconds()/3600
-    proj = float(trend(end_hour))
-
-    # 4) make subplot with secondary y-axis
+    # ── 3) Build figure with secondary y-axis ─────────────────────────────
     fig = make_subplots(specs=[[{"secondary_y": True}]])
 
-    # spot price (includes yday close)
     fig.add_trace(
         go.Scatter(
             x=price_series.index,
             y=price_series.values,
             mode="lines+markers",
             name="Spot Price",
-            line=dict(color="blue")
+            line=dict(color="blue"),
         ),
-        secondary_y=False
+        secondary_y=False,
     )
 
-    # delta exposure bars (today only)
     fig.add_trace(
         go.Bar(
             x=delta_series.index,
             y=delta_series.values,
             name="Net Delta Exposure",
             marker_color="red",
-            opacity=0.6
+            opacity=0.6,
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
-    # projection point
     fig.add_trace(
         go.Scatter(
-            x=[end_ts], y=[proj],
+            x=[end_ts],
+            y=[proj],
             mode="markers+lines",
             name="Projected Exposure",
             marker=dict(color="green", size=10),
-            line=dict(dash="dash")
+            line=dict(dash="dash"),
         ),
-        secondary_y=True
+        secondary_y=True,
     )
 
+    plot_date = price_series.index[1].date() if len(price_series) > 1 else price_series.index[0].date()
     fig.update_layout(
-        title=f"{ticker} Price & Net Delta Exposure Projection",
+        title=f"{ticker} {plot_date} Price & Net Delta Exposure Projection",
         xaxis=dict(title="Time"),
         template="plotly_white",
-        height=450, width=900
+        height=450,
+        width=900,
     )
     fig.update_yaxes(title_text="Spot Price", secondary_y=False)
     fig.update_yaxes(title_text="Delta Exposure", secondary_y=True)


### PR DESCRIPTION
## Summary
- make plot_price_and_delta_projection more robust
- add recent trading dates helper
- show date dropdown for intraday delta plot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840159a5f908322aa2bf295e59c5fc0