### PR TITLE
Add unit tests and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       
       - name: Install dependencies
         run: |
@@ -24,4 +24,4 @@ jobs:
           
       - name: Run tests
         run: |
-          pytest
+          pytest -q

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,51 @@
+import sys
+import os
+import types
+import pandas as pd
+import pytest
+
+# provide lightweight stand-ins for heavy optional deps imported by helpers
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+sys.modules.setdefault("yfinance", types.ModuleType("yfinance"))
+sys.modules.setdefault("feedparser", types.ModuleType("feedparser"))
+sys.modules.setdefault("streamlit", types.ModuleType("streamlit"))
+ta = types.ModuleType("tradier_api")
+ta.TradierAPI = object
+sys.modules.setdefault("tradier_api", ta)
+yaml = types.ModuleType("yaml")
+yaml.safe_load = lambda s: {}
+sys.modules.setdefault("yaml", yaml)
+
+from helpers import compute_put_call_ratios, compute_unusual_spikes
+
+
+def test_compute_put_call_ratios_basic():
+    data = [
+        {"option_type": "call", "volume": 100, "open_interest": 200},
+        {"option_type": "call", "volume": 100, "open_interest": 200},
+        {"option_type": "put",  "volume": 30,  "open_interest": 80},
+        {"option_type": "put",  "volume": 70,  "open_interest": 120},
+        {"option_type": "put",  "volume": 50,  "open_interest": 100},
+    ]
+    df = pd.DataFrame(data)
+    vol_r, oi_r = compute_put_call_ratios(df)
+    assert vol_r == pytest.approx(0.75)
+    assert oi_r == pytest.approx(0.75)
+
+
+def test_compute_unusual_spikes_simple():
+    data = [
+        {"strike": 100, "option_type": "put",  "volume": 10,  "open_interest": 5},
+        {"strike": 100, "option_type": "call", "volume": 5,   "open_interest": 10},
+        {"strike": 101, "option_type": "put",  "volume": 20,  "open_interest": 10},
+        {"strike": 101, "option_type": "call", "volume": 5,   "open_interest": 0},
+        {"strike": 102, "option_type": "put",  "volume": 0,   "open_interest": 50},
+        {"strike": 102, "option_type": "call", "volume": 100, "open_interest": 25},
+    ]
+    df = pd.DataFrame(data)
+    res = compute_unusual_spikes(df, top_n=2)
+    assert list(res["strike"]) == [102, 100]
+    assert list(res["vol_oi_call"]) == pytest.approx([4.0, 0.5])
+    assert list(res["vol_oi_put"]) == pytest.approx([0.0, 2.0])
+    assert list(res["total_vol_oi"]) == pytest.approx([4.0, 2.5])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,44 @@
+import sys
+import os
+import types
+import pandas as pd
+import pytest
+
+# dummy modules required by utils import
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+sys.modules.setdefault("yfinance", types.ModuleType("yfinance"))
+sys.modules.setdefault("seaborn", types.ModuleType("seaborn"))
+
+mpl = types.ModuleType("matplotlib")
+pyplot = types.ModuleType("matplotlib.pyplot")
+mpl.pyplot = pyplot
+sys.modules.setdefault("matplotlib", mpl)
+sys.modules.setdefault("matplotlib.pyplot", pyplot)
+sys.modules.setdefault("plotly", types.ModuleType("plotly"))
+sys.modules.setdefault("plotly.graph_objects", types.ModuleType("plotly.graph_objects"))
+sys.modules.setdefault("plotly.express", types.ModuleType("plotly.express"))
+plotly_subplots = types.ModuleType("plotly.subplots")
+plotly_subplots.make_subplots = lambda *a, **k: None
+sys.modules.setdefault("plotly.subplots", plotly_subplots)
+sys.modules["plotly.graph_objects"].Figure = object
+sys.modules.setdefault("matplotlib.dates", types.ModuleType("matplotlib.dates"))
+ta = types.ModuleType("tradier_api")
+ta.TradierAPI = object
+sys.modules.setdefault("tradier_api", ta)
+
+from utils import compute_net_gamma_exposure
+
+
+def test_compute_net_gamma_exposure_basic():
+    chain = [
+        {"strike": 100, "option_type": "call", "open_interest": 10, "contract_size": 100, "greeks": {"gamma": 0.5}},
+        {"strike": 100, "option_type": "put",  "open_interest": 5,  "contract_size": 100, "greeks": {"gamma": 0.2}},
+        {"strike": 101, "option_type": "call", "open_interest": 8,  "contract_size": 100, "greeks": {"gamma": 0.4}},
+        {"strike": 101, "option_type": "put",  "open_interest": 0,  "contract_size": 100, "greeks": {"gamma": 0.3}},
+        {"strike": 102, "option_type": "call", "open_interest": 5,  "contract_size": 100, "greeks": {}},
+        {"strike": 105, "option_type": "call", "open_interest": 10, "contract_size": 100, "greeks": {"gamma": 0.1}},
+    ]
+    df = compute_net_gamma_exposure(chain, S=100, offset=2)
+    assert list(df["Strike"]) == [100, 101]
+    assert list(df["Net GEX"]) == [400.0, 320.0]


### PR DESCRIPTION
## Summary
- add tests for helper and util functions
- mock optional heavy dependencies during testing
- update CI to run with Python 3.11 and use quiet pytest output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684021dd56f8832284d2ba83c9a1f807