### PR TITLE
Add market sentiment tab with futures

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,9 @@ tradier:
 tradingEconomics:
   api_url: "https://api.tradingeconomics.com"
 
+fred:
+  api_url: "https://api.stlouisfed.org/fred"
+
 news:
   rss_feeds:
     - "https://feeds.reuters.com/Reuters/BusinessNews"


### PR DESCRIPTION
## Summary
- add FRED config section
- support futures quotes and bid-to-cover ratio in helpers
- include pre-market market sentiment tab with futures and 10Y auction info

## Testing
- `python -m py_compile helpers.py app.py quant.py utils.py tradier_api.py db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491e82ade0832293e6dc30fbca469c