### PR TITLE
Add binomial tree feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,9 @@ from utils import (
     plot_volume_spikes_stacked,
     interpret_net_gex,
     plot_exposure,
-    plot_price_and_delta_projection
+    plot_price_and_delta_projection,
+    generate_binomial_tree,
+    plot_binomial_tree,
 )
 from quant import openai_query
 from db import init_db, save_analysis, load_analyses
@@ -63,22 +65,30 @@ if ticker:
 enable_ai = st.sidebar.checkbox("Enable AI Analysis", value=True)
 
 # --- Tabs ---
-tab_names = ["Overview Metrics", "Options Positioning", "Market Sentiment", "Market News", "Liquidity"]
+tab_names = [
+    "Overview Metrics",
+    "Options Positioning",
+    "Binomial Tree",
+    "Market Sentiment",
+    "Market News",
+    "Liquidity",
+]
 if enable_ai:
     tab_names.append("AI Analysis")
 tab_names.append("Economic Calendar")
 tabs = st.tabs(tab_names)
 tab1 = tabs[0]
 tab2 = tabs[1]
-sentiment_tab = tabs[2]
-news_tab = tabs[3]
-liq_tab = tabs[4]
+binom_tab = tabs[2]
+sentiment_tab = tabs[3]
+news_tab = tabs[4]
+liq_tab = tabs[5]
 if enable_ai:
-    ai_tab = tabs[5]
-    calender_tab = tabs[6]
+    ai_tab = tabs[6]
+    calender_tab = tabs[7]
 else:
     ai_tab = None
-    calender_tab = tabs[5]
+    calender_tab = tabs[6]
 
 # --- Tab 1: Overview Metrics ---
 with tab1:
@@ -224,6 +234,47 @@ with tab2:
 
     else:
         st.info("Select ticker and expirations to view positioning.")
+
+# --- Tab 3: Binomial Tree ---
+with binom_tab:
+    st.header("🧮 Binomial Tree")
+    if ticker and expirations and spot is not None:
+        exp = st.selectbox("Expiration", expirations)
+        token = st.secrets.get("TRADIER_TOKEN")
+        try:
+            chain = get_option_chain(ticker, exp, token, include_all_roots=True)
+        except Exception:
+            st.error("Failed to fetch options chain")
+            chain = []
+
+        strikes = sorted({float(opt.get("strike", 0)) for opt in chain})
+        default_strike = min(strikes, key=lambda x: abs(x - spot)) if strikes else spot
+        strike = st.number_input("Strike", value=float(default_strike))
+        opt_side = st.selectbox("Option Type", ["call", "put"])
+        steps = st.slider("Steps", 1, 25, 5)
+
+        rf = get_bond_yield_info("^TNX")["spot"] / 100
+        iv = None
+        for opt in chain:
+            if float(opt.get("strike", 0)) == strike and opt.get("option_type") == opt_side:
+                iv = opt.get("greeks", {}).get("iv") or opt.get("greeks", {}).get("mid_iv")
+                if iv:
+                    iv = float(iv)
+                    break
+        if iv is None:
+            iv = 0.2
+
+        T = (
+            datetime.strptime(exp, "%Y-%m-%d").date() - datetime.utcnow().date()
+        ).days / 365
+
+        if st.button("Build Tree"):
+            tree_df = generate_binomial_tree(spot, strike, T, rf, iv, steps, opt_side)
+            fig = plot_binomial_tree(tree_df)
+            st.plotly_chart(fig, use_container_width=True)
+            st.dataframe(tree_df)
+    else:
+        st.info("Enter ticker and expiration to build a tree.")
 
 # --- Tab 3: Market Sentiment ---
 with sentiment_tab:


### PR DESCRIPTION
## Summary
- integrate binomial tree generator and plot utilities
- add tab to display binomial tree for selected options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849af0b9ddc83229cc2cf9867a98c42