### PR TITLE
Expose AI model discovery before analysis prep

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ from utils import (
     generate_binomial_tree,
     plot_binomial_tree,
 )
-from quant import openai_query
+from quant import openai_query, render_model_selection
 from db import init_db, load_analyses
 
 
@@ -1481,26 +1481,28 @@ if enable_ai and ai_tab:
         if "want_ai" not in st.session_state:
             st.session_state.want_ai = False
 
+        openai_creds, selected_model = render_model_selection(ticker, selected_exps)
+
         if st.button("Prepare AI Analysis"):
             st.session_state.want_ai = True
 
         if st.session_state.want_ai:
-            openai_query(
-                df,
-                iv_skew_df,
-                vol_ratio,
-                oi_ratio,
-                articles,
-                spot,
-                offset,
-                ticker,
-                selected_exps,
-            )
-
-        if st.session_state.want_ai and st.button("Cancel AI Preparation"):
-            st.session_state.want_ai = False
-            st.session_state.pop("ai_model_confirmed", None)
-            st.session_state.pop("ai_selected_model", None)
+            if st.button("Cancel AI Preparation", key="cancel_ai_preparation"):
+                st.session_state.want_ai = False
+            else:
+                openai_query(
+                    df,
+                    iv_skew_df,
+                    vol_ratio,
+                    oi_ratio,
+                    articles,
+                    spot,
+                    offset,
+                    ticker,
+                    selected_exps,
+                    selected_model,
+                    openai_creds,
+                )
 
         st.markdown("---")
         st.header("📚 Past AI Analyses")

--- a/quant.py
+++ b/quant.py
@@ -599,17 +599,15 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
     </style>
     """
 
-    row_template = textwrap.dedent(
-        """
-        <tr class="{row_class}">
-            <td class="model-rank">#{rank:02d}</td>
-            <td class="model-id">{model_id}</td>
-            <td class="model-score">{score}</td>
-            <td>
-                <div class="model-strengths">{strengths}</div>
-            </td>
-        </tr>
-        """
+    row_template = (
+        "<tr class=\"{row_class}\">\n"
+        "  <td class=\"model-rank\">#{rank:02d}</td>\n"
+        "  <td class=\"model-id\">{model_id}</td>\n"
+        "  <td class=\"model-score\">{score}</td>\n"
+        "  <td>\n"
+        "    <div class=\"model-strengths\">{strengths}</div>\n"
+        "  </td>\n"
+        "</tr>"
     )
 
     rows_html: List[str] = []
@@ -641,28 +639,27 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
             )
         )
 
-    rows_markup = "".join(rows_html)
-    table_html = textwrap.dedent(
-        """
-        <div class="model-discovery-card">
-            <div class="model-discovery-card__table">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Rank</th>
-                            <th>Model</th>
-                            <th>Score</th>
-                            <th>Highlights</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {rows}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        """
-    ).format(rows=rows_markup)
+    rows_markup = "\n".join(rows_html)
+    rows_section = f"{rows_markup}\n" if rows_markup else ""
+    table_html = (
+        "<div class=\"model-discovery-card\">\n"
+        "<div class=\"model-discovery-card__table\">\n"
+        "<table>\n"
+        "<thead>\n"
+        "<tr>\n"
+        "<th>Rank</th>\n"
+        "<th>Model</th>\n"
+        "<th>Score</th>\n"
+        "<th>Highlights</th>\n"
+        "</tr>\n"
+        "</thead>\n"
+        "<tbody>\n"
+        f"{rows_section}"
+        "</tbody>\n"
+        "</table>\n"
+        "</div>\n"
+        "</div>"
+    )
 
     return textwrap.dedent(table_style) + table_html
 

--- a/quant.py
+++ b/quant.py
@@ -457,18 +457,37 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
         .model-discovery-card {
             margin-top: 0.85rem;
             border-radius: 18px;
-            padding: 1rem 1.25rem 0.6rem;
+            padding: 1rem 1.25rem 0.75rem;
             background: rgba(15, 23, 42, 0.6);
             border: 1px solid rgba(148, 163, 184, 0.22);
             box-shadow: 0 20px 42px rgba(2, 6, 23, 0.42);
         }
 
+        .model-discovery-card__table {
+            max-height: 320px;
+            overflow-y: auto;
+            margin: 0 -0.5rem;
+            padding: 0 0.5rem;
+        }
+
+        .model-discovery-card__table::-webkit-scrollbar {
+            width: 6px;
+        }
+
+        .model-discovery-card__table::-webkit-scrollbar-thumb {
+            background: rgba(148, 163, 184, 0.35);
+            border-radius: 999px;
+        }
+
         .model-discovery-card table {
             width: 100%;
             border-collapse: collapse;
+            min-width: 100%;
         }
 
         .model-discovery-card thead th {
+            position: sticky;
+            top: 0;
             text-transform: uppercase;
             font-size: 0.72rem;
             letter-spacing: 0.08em;
@@ -476,6 +495,8 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
             padding: 0.65rem 0.75rem;
             text-align: left;
             border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+            background: rgba(15, 23, 42, 0.96);
+            backdrop-filter: blur(6px);
         }
 
         .model-discovery-card tbody td {
@@ -487,6 +508,10 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
 
         .model-discovery-card tbody tr:last-child td {
             border-bottom: none;
+        }
+
+        .model-discovery-card__table::-webkit-scrollbar-track {
+            background: transparent;
         }
 
         .model-discovery-card .model-rank {
@@ -549,6 +574,12 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
 
             .model-discovery-card thead {
                 display: none;
+            }
+
+            .model-discovery-card__table {
+                max-height: none;
+                margin: 0;
+                padding: 0;
             }
 
             .model-discovery-card tbody td {
@@ -614,19 +645,21 @@ def _render_model_discovery_table(models: Sequence[Dict[str, object]]) -> str:
     table_html = textwrap.dedent(
         """
         <div class="model-discovery-card">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Rank</th>
-                        <th>Model</th>
-                        <th>Score</th>
-                        <th>Highlights</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows}
-                </tbody>
-            </table>
+            <div class="model-discovery-card__table">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Rank</th>
+                            <th>Model</th>
+                            <th>Score</th>
+                            <th>Highlights</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows}
+                    </tbody>
+                </table>
+            </div>
         </div>
         """
     ).format(rows=rows_markup)


### PR DESCRIPTION
## Summary
- surface the AI model discovery and selection UI by default in the AI Analysis tab
- reuse the selected or default model when preparing the AI payload so preparation always has a model choice

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e4cea14f888322a5943ac5220b6b83